### PR TITLE
Add initialOwner parameter to constructor

### DIFF
--- a/MetroMintXpress.sol
+++ b/MetroMintXpress.sol
@@ -20,7 +20,10 @@ contract MetroMintXpress is ERC721, Ownable {
 
     event TicketUsed(uint256 indexed tokenId);
 
-    constructor() ERC721("MetroMint Xpress Ticket", "MMT") {}
+    constructor(address initialOwner)
+        ERC721("MetroMint Xpress Ticket", "MMT")
+        Ownable(initialOwner)
+    {}
 
     function mintTicket(address _to, string memory _origin, string memory _destination)
         public
@@ -42,6 +45,7 @@ contract MetroMintXpress is ERC721, Ownable {
     }
 
     function isTicketValid(uint256 _tokenId) public view returns (bool) {
+        // _exists is a more gas-efficient way to check if a token ID is valid.
         return _exists(_tokenId) && !ticketDetails[_tokenId].isUsed;
     }
 


### PR DESCRIPTION
The contract constructor now accepts an initialOwner address, which is passed to the Ownable base contract. This change allows for more flexible ownership assignment at deployment. Also added a comment explaining the use of _exists in isTicketValid for gas efficiency.